### PR TITLE
Add metadata_startup_script support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,7 @@ resource "google_compute_instance" "default" {
   enable_display            = var.enable_display
   labels                    = var.labels
   metadata                  = var.metadata
+  metadata_startup_script   = var.metadata_startup_script
 
   dynamic "attached_disk" {
     for_each = local.attached_disks_zonal

--- a/variables.tf
+++ b/variables.tf
@@ -179,6 +179,12 @@ variable "metadata" {
   default     = {}
 }
 
+variable "metadata_startup_script" {
+  description = "Instance metadata startup script."
+  type        = string
+  default     = null
+}
+
 variable "min_cpu_platform" {
   description = "Minimum CPU platform."
   type        = string


### PR DESCRIPTION
Adds support to specify a startup script for the instance.