### PR TITLE
Module update google v6

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "guest_accelerator" {
       count = number
     })
   )
-  default = []
+  default = 0
 }
 
 variable "hostname" {

--- a/versions.tf
+++ b/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.25.0" # tftest
+      version = ">= 6.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.25.0" # tftest
+      version = ">= 6.0" # tftest
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.0" # tftest
+      version = ">= 4.25.0" # tftest
     }
   }
 }


### PR DESCRIPTION
Altered default value for guest accelerator for compatibility with google provider version 6

https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_6_upgrade#guest_accelerator---is-no-longer-valid-configuration
